### PR TITLE
Improve UI, add delete chat, quiz improvements and consistent AI prompt

### DIFF
--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -21,12 +21,16 @@ class ChatsController < ApplicationController
         @chat.messages.create(content: @chat.title, user: current_user, role: "user")
 
         # Get AI response
-        instructions = "You are a world-class historian specializing in #{@chat.title}."
-        history = [{ role: "user", content: @chat.title }]
-        ai_content = RubyLLM.chat(model: "claude-haiku-4-5-20251001")
-                      .with_instructions(instructions)
-                      .ask(history)
-                      .content
+        instructions = <<~PROMPT
+          #{@topic.ai_instructions}
+          The user's name is #{current_user.name}.
+          Always use their name when replying.
+          The current topic is: #{@topic.title}.
+          You must only answer questions about this topic.
+        PROMPT
+        chat_ai = RubyLLM.chat(model: "claude-haiku-4-5-20251001")
+                    .with_instructions(instructions)
+        ai_content = chat_ai.ask(@chat.title).content
         @chat.messages.create(role: "assistant", content: ai_content, user: current_user)
 
         redirect_to chat_path(@chat), notice: "Chat started successfully!"
@@ -38,6 +42,13 @@ class ChatsController < ApplicationController
   def index
     @topic = Topic.find(params[:topic_id])
     @chats = @topic.chats
+  end
+
+  def destroy
+    @chat = Chat.find(params[:id])
+    @topic = @chat.topic
+    @chat.destroy
+    redirect_to topic_path(@topic), notice: "Chat deleted successfully!"
   end
 
   private

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -29,7 +29,8 @@ class TopicsController < ApplicationController
         ]
       }
       Do not include any explanation or extra text.
-      Include a random number between 1-1000 in the JSON comment field to force variation: #{rand(1..1000)}
+      You MUST generate a completely different question every time. Never repeat a question.
+      This request has a unique ID to ensure variation: #{SecureRandom.hex(8)}
     INSTR
 
     begin

--- a/app/views/chats/show.html.erb
+++ b/app/views/chats/show.html.erb
@@ -1,18 +1,21 @@
-<% if @chat %>
-  <div class="chat-container mx-auto p-4 border rounded" style="max-width: 600px; background-color: #f8f9fa;">
-    <h2 class="mb-3">Chat about <%= @topic.title %></h2>
+<div class="mx-auto mt-5" style="max-width: 780px;">
 
-    <div id="messages" class="messages mb-3 border rounded p-3" style="height: 400px; overflow-y: auto;">
-      <%= render "messages/messages", messages: @messages %>
-    </div>
+  <%= link_to "← Back to Topic", topic_path(@chat.topic), class: "btn btn-outline-secondary btn-sm mb-3", style: "border-radius: 20px;" %>
 
-    <div id="new_message_container">
-      <%= render "messages/form", chat: @chat, message: @message %>
-    </div>
+  <% if @chat %>
+    <div class="chat-container p-4" style="background-color: #f8f9fa; border-radius: 16px; box-shadow: 0 4px 24px rgba(0,0,0,0.08);">
 
-    <hr>
-    <div class="mt-3">
-      <%= link_to "Back to Topic", topic_path(@chat.topic), class: "btn btn-outline-secondary" %>
+      <h2 class="mb-3">Chat about <%= @topic.title %></h2>
+
+      <div id="messages" class="messages mb-3 p-3" style="height: 550px; overflow-y: auto;">
+        <%= render "messages/messages", messages: @messages %>
+      </div>
+
+      <div id="new_message_container">
+        <%= render "messages/form", chat: @chat, message: @message %>
+      </div>
+
     </div>
-  </div>
-<% end %>
+  <% end %>
+
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   </head>
 
   <body>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -1,7 +1,9 @@
 <%= form_with model: [chat, message], local: false do |f| %>
-  <div class="mb-2">
-    <%= f.text_area :content, placeholder: "Type your question...", rows: 4, class: "form-control" %>
+  <div class="d-flex gap-2 align-items-end">
+    <%= f.text_area :content, placeholder: "Type your question...", rows: 1, class: "form-control",
+        style: "border-radius: 20px; padding: 10px 16px; resize: none; overflow: hidden; min-height: 42px;",
+        oninput: "this.style.height='auto'; this.style.height=this.scrollHeight+'px'" %>
     <%= f.hidden_field :role, value: "user" %>
+    <%= f.submit "Send", class: "btn btn-primary", style: "border-radius: 20px; padding: 8px 24px; white-space: nowrap;" %>
   </div>
-  <%= f.submit "Send", class: "btn btn-primary" %>
 <% end %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,29 +1,33 @@
-<div class="container mt-5">
-  <h1 class="display-4 text-primary"><%= @topic.title %></h1>
+<div class="container mt-5" style="max-width: 780px;">
+  <%= link_to "← Back to All Topics", topics_path, class: "btn btn-outline-secondary btn-sm mb-3", style: "border-radius: 20px;" %>
 
-  <div class="card my-4 shadow-sm">
-    <div class="card-body">
-      <p class="lead"><%= @topic.description %></p>
+  <div class="p-4" style="background-color: #f8f9fa; border-radius: 16px; box-shadow: 0 4px 24px rgba(0,0,0,0.08);">
+    <h1 class="display-4 text-primary"><%= @topic.title %></h1>
+
+    <p class="lead"><%= @topic.description %></p>
+
+    <div class="d-flex gap-2 mb-5">
+      <%= link_to "Start a New Chat", new_topic_chat_path(@topic), class: "btn btn-success btn-lg" %>
+
+      <button type="button" class="btn btn-warning btn-lg" data-bs-toggle="modal" data-bs-target="#quizModal" data-topic-id="<%= @topic.id %>">
+        Generate Quiz Question
+      </button>
     </div>
-  </div>
 
-  <div class="d-flex gap-2 mb-5">
-    <%= link_to "Start a New Chat", new_topic_chat_path(@topic), class: "btn btn-success btn-lg" %>
-
-    <button type="button" class="btn btn-warning btn-lg" data-bs-toggle="modal" data-bs-target="#quizModal" data-topic-id="<%= @topic.id %>">
-      Generate Quiz Question
-    </button>
-
-    <%= link_to "Back to All Topics", topics_path, class: "btn btn-outline-secondary btn-lg" %>
-  </div>
-
-
-  <div class="mt-5">
-    <h3 class="mb-3">Your Previous Chats in this Topic:</h3>
-    <div class="list-group">
-      <% @topic.chats.where(user: current_user).each do |chat| %>
-        <%= link_to chat.title, chat_path(chat), class: "list-group-item list-group-item-action" %>
-      <% end %>
+    <div class="mt-5">
+      <h3 class="mb-3">Your Previous Chats in this Topic:</h3>
+      <div class="list-group">
+        <% @topic.chats.where(user: current_user).each do |chat| %>
+          <div class="list-group-item d-flex justify-content-between align-items-center chat-row">
+            <%= link_to chat.title, chat_path(chat) %>
+            <%= button_to chat_path(chat), method: :delete,
+                class: "btn btn-sm btn-link text-secondary chat-delete-btn",
+                form: { data: { turbo_confirm: "Are you sure you want to delete this chat?" } } do %>
+              <i class="fa-regular fa-trash-can"></i>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>
@@ -46,6 +50,30 @@
 <script>
 let quizLoading = false;
 
+function loadQuiz(topicId, quizContent, handleClick) {
+  quizContent.innerHTML = "<p>Loading question...</p>";
+  fetch(`/topics/${topicId}/generate_quiz`)
+    .then(r => r.json())
+    .then(quiz => {
+      quizContent.innerHTML = `
+        <p class="lead">${quiz.question}</p>
+        <div id="quizButtons" class="d-grid gap-2">
+          ${quiz.answers.map(a => `<button class="quiz-option btn btn-outline-primary mb-2 w-100" data-correct="${a.correct}">${a.text}</button>`).join('')}
+        </div>
+        <button id="tryAnother" class="btn btn-outline-secondary mt-3 w-100" style="border-radius: 20px; display:none;">
+          Try another question
+        </button>
+      `;
+      document.getElementById("quizButtons").addEventListener("click", handleClick);
+      document.getElementById("tryAnother").addEventListener("click", () => {
+        loadQuiz(topicId, quizContent, handleClick);
+      });
+    })
+    .catch(() => {
+      quizContent.innerHTML = "<p class='text-danger'>Failed to load quiz. Please try again.</p>";
+    });
+}
+
 document.addEventListener("turbo:load", () => {
   const quizModal = document.getElementById("quizModal");
   const quizContent = document.getElementById("quizContent");
@@ -58,59 +86,39 @@ document.addEventListener("turbo:load", () => {
     if (!button) return;
 
     const topicId = button.dataset.topicId;
-    quizContent.innerHTML = "<p>Loading question...</p>";
 
-    try {
-      const response = await fetch(`/topics/${topicId}/generate_quiz`);
-      if (!response.ok) throw new Error("Network error");
+    const handleClick = (e) => {
+      const btn = e.target.closest(".quiz-option");
+      if (!btn) return;
 
-      const quiz = await response.json();
+      document.getElementById("quizButtons").querySelectorAll(".quiz-option").forEach(b => {
+        if (b.dataset.correct === "true") b.classList.replace("btn-outline-primary", "btn-success");
+        else if (b === btn) b.classList.replace("btn-outline-primary", "btn-danger");
+        b.disabled = true;
+      });
 
-      if (!quiz.answers || quiz.answers.length !== 3) {
-        quizContent.innerHTML = "<p class='text-danger'>Failed to generate quiz. Try again.</p>";
-        return;
+      if (btn.dataset.correct === "true") {
+        try {
+          confetti({ particleCount: 100, spread: 70, origin: { y: 0.6 } });
+        } catch(err) { console.warn(err); }
       }
 
-      quizContent.innerHTML = `
-        <p class="lead">${quiz.question}</p>
-        <div id="quizButtons" class="d-grid gap-2">
-          ${quiz.answers.map(a => `<button class="quiz-option btn btn-outline-primary mb-2 w-100" data-correct="${a.correct}">${a.text}</button>`).join('')}
-        </div>
-      `;
-
-      const quizButtons = document.getElementById("quizButtons");
-
-      const handleClick = (e) => {
-        const btn = e.target.closest(".quiz-option");
-        if (!btn) return;
-
-        quizButtons.querySelectorAll(".quiz-option").forEach(b => {
-          if (b.dataset.correct === "true") b.classList.replace("btn-outline-primary","btn-success");
-          else if (b === btn) b.classList.replace("btn-outline-primary","btn-danger");
-          b.disabled = true;
-        });
-
-        if (btn.dataset.correct === "true") {
-          try {
-            confetti({ particleCount: 100, spread: 70, origin: { y: 0.6 } });
-          } catch(err) { console.warn(err); }
-        }
-
-        quizButtons.removeEventListener("click", handleClick); // evita duplicados
-      };
-
-      quizButtons.addEventListener("click", handleClick);
-
-    } catch(err) {
-      console.error(err);
-      quizContent.innerHTML = "<p class='text-danger'>Failed to load quiz. Please try again.</p>";
-    } finally {
+      document.getElementById("quizButtons").removeEventListener("click", handleClick); // evita duplicados
+      document.getElementById("tryAnother").style.display = "block";
       quizLoading = false;
-    }
+    };
+
+    loadQuiz(topicId, quizContent, handleClick);
   });
 
   quizModal.addEventListener("hidden.bs.modal", () => {
     quizContent.innerHTML = "Loading quiz...";
+    quizLoading = false;
   });
 });
 </script>
+
+<style>
+  .chat-delete-btn { opacity: 0; transition: opacity 0.2s ease; }
+  .chat-row:hover .chat-delete-btn { opacity: 1; }
+</style>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     resources :chats, only: [:index, :new, :create]
     get :generate_quiz, on: :member
   end
-  resources :chats, only: [:show] do
+  resources :chats, only: [:show, :destroy] do
     resources :messages, only: [:create]
   end
 end


### PR DESCRIPTION
### Summary of changes
**UI — /topics/:id**

- Added box shadow, removed card border around description
- Moved "Back to All Topics" button above the topic card
- Reduced page width to 780px for better readability
- Trash icon on previous chats only visible on hover

**UI — /chats/:id**

- Moved "Back to Topic" button outside and above the chat card
- Pill-shaped message input that grows dynamically with content
- Send button beside the input, also pill-shaped
- Box shadow on chat card, removed border
- Widened container to 780px
- Added Font Awesome via CDN for icons

**Delete chat**

- Added destroy action to ChatsController and :destroy to routes
- Trash icon button on each previous chat row with confirmation popup

**Quiz improvements**

- "Try another question" button hidden until user answers
- Refactored quiz JS into reusable function
- Improved question variation

**AI prompt**

- Updated ChatsController#create to use @topic.ai_instructions — consistent with MessagesController